### PR TITLE
chore: add GHA

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,44 @@
+name: "Go"
+
+on:
+  merge_group:
+    types:
+      - checks_requested
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+      - prod
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - name: Golang CI Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59.0
+          args: --timeout=10m --issues-exit-code=0
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Run test
+        id: test
+        run: docker compose run --rm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.23.0 AS builder
+
+WORKDIR /app
+COPY go.* ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /tmp/build/data-producer ./cmd
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /tmp/build/data-producer /
+
+EXPOSE 8080
+
+CMD ["/data-producer"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,10 @@
+FROM golang:1.23.0
+
+WORKDIR /app
+
+COPY go.* ./
+RUN go mod download
+
+COPY . .
+
+CMD ["go", "test", "./...", "-v"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,5 @@
+services:
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile.test


### PR DESCRIPTION
This pull request introduces a new CI/CD pipeline for the Go project, adds Docker support for building and testing, and sets up a Docker Compose configuration for running tests. The most important changes include the addition of a GitHub Actions workflow, a Dockerfile for building the application, a Dockerfile for running tests, and a Docker Compose configuration for the test service.

CI/CD Pipeline:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR1-R44): Added a GitHub Actions workflow to lint and test the Go project on pull requests and pushes to the `main` and `prod` branches.

Docker Support:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R15): Added a Dockerfile to build the Go application using a multi-stage build process.
* [`Dockerfile.test`](diffhunk://#diff-5faf10fde2b24acdf4f05e70be1be9d50921d685e64f781d242e056b11d79dccR1-R10): Added a Dockerfile to run tests for the Go project.

Docker Compose Configuration:

* [`compose.yml`](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R1-R5): Added a Docker Compose configuration to define a service for running tests using the `Dockerfile.test`.